### PR TITLE
Reformat code to standard using rustfmt

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,17 +3,4 @@ edition = "2021"
 array_width = 70
 fn_params_layout = "Compressed"
 fn_call_width = 80
-fn_single_line = true
-space_before_colon = false
-spaces_around_ranges = true
-unstable_features = true
-
-wrap_comments = true
 max_width = 100
-comment_width = 90
-
-# These work only for nightly builds (of rust toolchain), as of rust v 1.71
-control_brace_style = "AlwaysNextLine"
-brace_style = "AlwaysNextLine"
-struct_field_align_threshold = 40
-enum_discrim_align_threshold = 40


### PR DESCRIPTION
- Migrated from nightly to stable Rust build
- Removed unsupported settings from rustfmt.toml