### PR TITLE
Feat/cli refactor ci tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install stable Rust (uses rust-toolchain.toml if present)
+      - uses: dtolnay/rust-toolchain@stable
+
+      # Optional-but-nice cache so builds are fast
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: fmt check
+        run: cargo fmt --all -- --check
+
+      - name: clippy (deny warnings)
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: tests
+        run: cargo test --all-features --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+All notable changes to **rc5-course** will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased]
+
+## [0.2.0] – 2025-05-03
+### Added
+- **CLI** moved to `src/bin/rc5-cbc.rs`; helper functions now accept `&[u8]` and trim zero-padding.
+- Integration & property tests:
+  - `tests/block.rs` – Rivest vector #2 (RC5-32/12/16)
+  - `tests/roundtrip.rs` – proptest random block round-trips
+  - `tests/cli.rs` – end-to-end file encrypt/decrypt via CLI
+- GitHub Actions workflow: `fmt`, `clippy -D warnings`, and `cargo test`.
+- CI status badge in README.
+
+### Changed
+- Library API: `encrypt`, `decrypt`, `expand_key` now take `&[u8]` instead of `Vec<u8>`.
+- Re-exported `rc5` module via new `src/lib.rs`.
+- README rewritten with build instructions and usage.
+
+### Removed
+- Old `examples/rc5cli.rs` duplicate build target (now a single binary).
+
+---
+
+[Unreleased]: https://github.com/JohnBasrai/rc5-cbc/compare/v0.2.0...HEAD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc5-course"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,18 @@
 [package]
 name = "rc5-course"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.75"
+anyhow = "1"
 clap = { version = "4", features = ["derive"] }
-num = "0.4.0"
+num = "0.4"
 
-[[bin]]
-name = "rc5-cbc"
-path = "./src/rc5-cbc.rs"
+[dev-dependencies]
+proptest    = "1"
+rand        = "0"
+assert_cmd  = "2"
+predicates  = "3"
+tempfile    = "3"

--- a/README.md
+++ b/README.md
@@ -1,37 +1,55 @@
-# rc5-cbc
-RC5 Symmetric Block Cipher in Rust
+# RC5 in Rust [![CI](https://github.com/JohnBasrai/rc5-cbc/actions/workflows/rust.yml/badge.svg)](https://github.com/JohnBasrai/rc5-cbc/actions/workflows/rust.yml)
 
-RC5 is a symmetric key block encryption algorithm designed by Ron Rivest in 1994. It is
-notable for being simple, fast (on account of using only primitive computer operations
-like XOR, shift, etc.) and consumes less memory.  Making Rust an idle language to
-implement it in.
+RC5 is a symmetric-key block-cipher designed by Ron Rivest in 1994.  
+It is notable for being simple and fast (it uses only primitive operations such as XOR and data-dependent rotations) and for its small memory footprint. Those properties make Rust an **ideal** language in which to implement it.
 
-Rivest original paper is [The RC5 Encryption Algorithm](https://people.csail.mit.edu/rivest/pubs/Riv94.pdf)
+---
+
+## Building the library & CLI
+
+```console
+# build everything in debug mode
+$ cargo build
+```
+
+The CLI lives in `src/bin/rc5-cbc.rs` and is built automatically as the `rc5-cbc` binary.
+
+---
 
 ## Usage
+
+### Encrypt
+
+```console
+$ cargo run --release --bin rc5-cbc -- \
+    --input plain.txt --output secret.rc5 encrypt
+Passphrase: ********
 ```
-$ cargo build                                                                  
-    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
-target/debug/rc5-cbc --input file.in --output file.out encrypt
 
-Passphrase: Mary had a little lamb
-$
+### Decrypt
+
+```console
+$ cargo run --release --bin rc5-cbc -- \
+    --input secret.rc5 --output recovered.txt decrypt
+Passphrase: ********
 ```
 
-## Help message
+---
+
+## Running tests & lints
+
+```console
+# unit + integration + property tests
+$ cargo test
+
+# static analysis
+$ cargo clippy --all-targets --all-features
 ```
-$ target/debug/rc5-cbc --help
-RC5 Symmetric Block Cipher in Rust
 
-Usage: rc5-cbc --input <IN_PATH> --output <OUT_PATH> <COMMAND>
+All tests should pass and Clippy should emit no warnings.
 
-Commands:
-  encrypt  Encrypt a file
-  decrypt  Decrypt a file
-  help     Print this message or the help of the given subcommand(s)
+---
 
-Options:
-  -i, --input <IN_PATH>    Input plaintext file
-  -o, --output <OUT_PATH>  Output ciphertext file
-  -h, --help               Print help
-```
+## License
+
+This project is licensed under the MIT License – see [`LICENSE`](LICENSE) for details.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+// re-export everything so tests can `use rc5::*;`
+pub mod rc5;

--- a/src/rc5.rs
+++ b/src/rc5.rs
@@ -65,7 +65,7 @@ impl Word for u32 {
 //     A = ((A ^ B) << B) + S[2 * i]
 //     B = ((B ^ A) << A) + S[2 * i + 1]
 //
-pub fn encrypt<W: Word>(pt: [W; 2], key: &Vec<u8>, rounds: usize) -> [W; 2] {
+pub fn encrypt<W: Word>(pt: [W; 2], key: &[u8], rounds: usize) -> [W; 2] {
     let s = expand_key(key, rounds);
 
     let [mut a, mut b] = pt;
@@ -87,7 +87,7 @@ pub fn encrypt<W: Word>(pt: [W; 2], key: &Vec<u8>, rounds: usize) -> [W; 2] {
 // B = B - S[1]
 // A = A - S[0]
 //
-pub fn decrypt<W: Word>(ct: [W; 2], key: &Vec<u8>, rounds: usize) -> [W; 2] {
+pub fn decrypt<W: Word>(ct: [W; 2], key: &[u8], rounds: usize) -> [W; 2] {
     let s = expand_key(key, rounds);
 
     let [mut a, mut b] = ct;
@@ -128,13 +128,13 @@ pub fn decrypt<W: Word>(ct: [W; 2], key: &Vec<u8>, rounds: usize) -> [W; 2] {
 //
 // input: key: Vec<u8>
 // output: S: Vec<W>
-pub fn expand_key<W: Word>(key: &Vec<u8>, rounds: usize) -> Vec<W> {
+pub fn expand_key<W: Word>(key: &[u8], rounds: usize) -> Vec<W> {
     let w = W::BYTES * 8;
     let b = key.len();
     let t = 2 * (rounds + 1);
 
     // ceil(8*b/w) = (8 * b + (w - 1)) / w
-    let tmp = (8 * b + (w - 1)) / w;
+    let tmp = (8 * b).div_ceil(w);
     let c = std::cmp::max(1, tmp);
     let mut key_l = vec![W::ZERO; c];
 

--- a/tests/block.rs
+++ b/tests/block.rs
@@ -1,0 +1,35 @@
+//! Verifies the RC5-32/12/16 test vector from Rivest (1994).
+
+use rc5_course::rc5::{decrypt, encrypt};
+
+/// Split a 64-bit value into the two 32-bit words RC5-32 operates on.
+fn split_u64(v: u64) -> [u32; 2] {
+    [(v >> 32) as u32, v as u32]
+}
+
+/// Join two 32-bit words back into a single `u64` (big-endian order).
+fn join_u64(words: [u32; 2]) -> u64 {
+    ((words[0] as u64) << 32) | (words[1] as u64)
+}
+
+#[test]
+fn enc_dec_single() {
+    // Canonical key/plaintext/ciphertext (RC5-32/12/16)
+    let key: [u8; 16] = [
+        0x91, 0x5F, 0x46, 0x19, 0xBE, 0x41, 0xB2, 0x51, 0x63, 0x55, 0xA5, 0x01, 0x10, 0xA9, 0xCE,
+        0x91,
+    ];
+
+    // Rivest test-vector #2  (RC5-32/12/16, same 16-byte key)
+    let plain: u64 = 0xEE_DB_A5_21_6D_8F_4B_15;
+    let cipher: u64 = 0xAC_13_C0_F7_52_89_2B_5B;
+    let rounds = 12;
+
+    // --- encrypt ---
+    let ct_words = encrypt::<u32>(split_u64(plain), &key, rounds);
+    assert_eq!(join_u64(ct_words), cipher, "encrypt mismatch");
+
+    // --- decrypt ---
+    let dt_words = decrypt::<u32>(split_u64(cipher), &key, rounds);
+    assert_eq!(join_u64(dt_words), plain, "decrypt mismatch");
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,40 @@
+use assert_cmd::Command;
+use std::fs;
+
+#[test]
+fn cli_round_trip_file() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let plain = temp.path().join("plain.txt");
+    let cipher = temp.path().join("cipher.bin");
+    let out = temp.path().join("out.txt");
+    fs::write(&plain, b"Hello RC5!")?;
+
+    // encrypt
+    Command::cargo_bin("rc5-cbc")?
+        .args([
+            "--input",
+            plain.to_str().unwrap(),
+            "--output",
+            cipher.to_str().unwrap(),
+            "encrypt",
+        ])
+        .write_stdin("pass\n") // passphrase prompt
+        .assert()
+        .success();
+
+    // decrypt
+    Command::cargo_bin("rc5-cbc")?
+        .args([
+            "--input",
+            cipher.to_str().unwrap(),
+            "--output",
+            out.to_str().unwrap(),
+            "decrypt",
+        ])
+        .write_stdin("pass\n")
+        .assert()
+        .success();
+
+    assert_eq!(fs::read(plain)?, fs::read(out)?);
+    Ok(())
+}

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,0 +1,38 @@
+//! Property-based round-trip test for RC5 block encryption.
+//!
+//! Instead of the old `encrypt_cbc` / `decrypt_cbc` helpers (which no longer
+//! exist) we call the block functions directly.
+
+use proptest::prelude::*;
+use rc5_course::rc5::{decrypt, encrypt};
+
+/// Strategy that produces a single RC5 block (two 32-bit words).
+fn rc5_block() -> impl Strategy<Value = [u32; 2]> {
+    (any::<u32>(), any::<u32>()).prop_map(|(a, b)| [a, b])
+}
+
+proptest! {
+    #[test]
+    fn round_trip_random(
+        // 1‥200 random blocks of plaintext
+        plaintext in prop::collection::vec(rc5_block(), 1..200),
+        // exactly-16-byte secret key
+        key in prop::collection::vec(any::<u8>(), 16),
+    ) {
+        let rounds = 12;
+
+        // --- encrypt every block ---
+        let ciphertext: Vec<[u32; 2]> =
+            plaintext.iter()
+                     .map(|&pt| encrypt::<u32>(pt, &key, rounds))
+                     .collect();
+
+        // --- decrypt back ---
+        let decrypted: Vec<[u32; 2]> =
+            ciphertext.iter()
+                      .map(|&ct| decrypt::<u32>(ct, &key, rounds))
+                      .collect();
+
+        prop_assert_eq!(plaintext, decrypted);
+    }
+}


### PR DESCRIPTION
### Summary
Refactors the CLI, adds a full test-suite (unit, property, integration), wires up GitHub Actions CI, **and introduces an official CHANGELOG**.

### Key changes
* **CLI**
  * Moved to `src/bin/rc5-cbc.rs`; helpers now take `&[u8]` and trim zero-padding.
* **Library API**
  * `encrypt`, `decrypt`, `expand_key` accept `&[u8]` (no `Vec` ownership).
  * Re-exported via new `src/lib.rs` so external code can `use rc5_course::rc5::*`.
* **Tests**
  * `tests/block.rs` – Rivest vector #2 (RC5-32/12/16)  
  * `tests/roundtrip.rs` – proptest random block round-trips  
  * `tests/cli.rs` – end-to-end file encrypt/decrypt via CLI
* **Tooling**
  * Added dev-deps: `proptest`, `assert_cmd`, `predicates`, `tempfile`.
  * GitHub Actions workflow (`.github/workflows/rust.yml`) with fmt, clippy (-D warnings), and tests.
* **Docs**
  * README overhaul + CI badge  
  * **New `CHANGELOG.md` following Keep-a-Changelog format**
* **Version bump** → **0.2.0**

### Checklist
- [x] `cargo fmt --check` passes  
- [x] `cargo clippy --all-targets --all-features -D warnings` passes  
- [x] `cargo test --all-features` passes locally  
- [x] CI workflow green   